### PR TITLE
Clean up Gradle scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download
 Gradle:
 
 ```groovy
-compile 'com.mattprecious.swirl:swirl:1.1.0'
+implementation 'com.mattprecious.swirl:swirl:1.1.0'
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,34 @@
-allprojects {
-  buildscript {
-    repositories {
-      google()
-      mavenCentral()
-      jcenter()
-    }
+buildscript {
+  ext.versions = [
+    'supportLibrary': '28.0.0-alpha3',
+  ]
+
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
   }
+
   dependencies {
-    repositories {
-      google()
-      mavenCentral()
-      jcenter()
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
+}
+
+subprojects {
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
+  }
+
+  configurations.all {
+    resolutionStrategy {
+      eachDependency { details ->
+        // Force all of the primary support libraries to use the same version.
+        if (details.requested.group == 'com.android.support') {
+          details.useVersion versions.supportLibrary
+        }
+      }
     }
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 14 14:09:48 EST 2015
+#Thu Jun 14 12:32:11 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip

--- a/swirl-sample/build.gradle
+++ b/swirl-sample/build.gradle
@@ -1,22 +1,11 @@
-buildscript {
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
-  }
-}
-
 apply plugin: 'com.android.application'
 
-dependencies {
-  compile project(':swirl')
-
-  implementation 'com.jakewharton:butterknife:8.8.1'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
-}
-
 android {
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 28
     versionName VERSION_NAME
   }
 
@@ -28,4 +17,11 @@ android {
   lintOptions {
     abortOnError false
   }
+}
+
+dependencies {
+  implementation project(':swirl')
+
+  implementation 'com.jakewharton:butterknife:8.8.1'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/swirl-sample/src/main/AndroidManifest.xml
+++ b/swirl-sample/src/main/AndroidManifest.xml
@@ -1,12 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="1"
-    package="com.mattprecious.swirl.sample"
-    >
-
-  <uses-sdk
-      android:minSdkVersion="21"
-      android:targetSdkVersion="23"
-      />
+    package="com.mattprecious.swirl.sample">
 
   <application
       android:allowBackup="true"

--- a/swirl/build.gradle
+++ b/swirl/build.gradle
@@ -1,16 +1,10 @@
-buildscript {
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
-  }
-}
-
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   defaultConfig {
-    minSdkVersion 14
+    minSdkVersion 15
     versionName VERSION_NAME
     vectorDrawables.useSupportLibrary = true
   }
@@ -24,9 +18,8 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:27.0.2'
-  compile 'com.android.support:support-vector-drawable:27.0.2'
-  compile 'com.android.support:animated-vector-drawable:27.0.2'
+  implementation "com.android.support:support-annotations:${versions.supportLibrary}"
+  implementation "com.android.support:animated-vector-drawable:${versions.supportLibrary}"
 }
 
 apply from: 'gradle-mvn-push.gradle'

--- a/swirl/src/main/AndroidManifest.xml
+++ b/swirl/src/main/AndroidManifest.xml
@@ -1,7 +1,1 @@
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="1"
-    package="com.mattprecious.swirl"
-    >
-  <uses-sdk android:minSdkVersion="15"/>
-</manifest>
+<manifest package="com.mattprecious.swirl"/>


### PR DESCRIPTION
* Bumped Gradle to 4.8
* Bumped Android Gradle Plugin to 3.1.3
* Bumped minSdk/compileSdk to 15/28
* Moved buildscript block to root project; subprojects inherit this from the root project
* Added support lib force resolution strategy block
* Updated README to use `implementation` Gradle configuration
* Moved minSdk and targetSdk versions from the manifest to the defaultOptions block
* Bumped support library version to 28.0.0-alpha3

Tested on a stock API 25 emulator.

Closes #9 